### PR TITLE
STM32F4 Support introduction

### DIFF
--- a/Modelica_DeviceDrivers/Blocks/InputDevices.mo
+++ b/Modelica_DeviceDrivers/Blocks/InputDevices.mo
@@ -23,7 +23,7 @@ package InputDevices
     when sample(0,sampleTime) then
       (AxesRaw,buttons_,pOV_) = Modelica_DeviceDrivers.InputDevices.GameController_.getData(joystick);
       buttons = buttons_;
-      pOV = poV_;
+      pOV = pOV_;
     end when;
     axes = (AxesRaw .- 32768)/32768 ./gain;
     annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,

--- a/Modelica_DeviceDrivers/Resources/test/OperatingSystem/test_MDDRealtimeSynchronize_high.c
+++ b/Modelica_DeviceDrivers/Resources/test/OperatingSystem/test_MDDRealtimeSynchronize_high.c
@@ -11,7 +11,7 @@ int main(void) {
   printf("Priority \"high\" with Ts=%lf...\n", Ts);
   MDD_setPriority(procPrio, 1);
   for (simTime=Ts; simTime < 1.0; simTime += Ts) {
-    calculationTime = MDD_realtimeSynchronize(rtSync, simTime, &availableTime);
+    calculationTime = MDD_realtimeSynchronize(rtSync, simTime, 0, 1, &availableTime);
     printf("simTime: %lf, availableTime: %lf, calculationTime: %lf\n", simTime, availableTime, calculationTime);
     alwaysInTime = alwaysInTime && availableTime > 0;
   }
@@ -21,4 +21,3 @@ int main(void) {
 
   return !(alwaysInTime  > 0); /* Need to invert boolean value since a zero return value indicates success */
 }
-

--- a/Modelica_DeviceDrivers/Resources/test/OperatingSystem/test_MDDRealtimeSynchronize_idle.c
+++ b/Modelica_DeviceDrivers/Resources/test/OperatingSystem/test_MDDRealtimeSynchronize_idle.c
@@ -11,7 +11,7 @@ int main(void) {
   printf("Priority \"Idle\" with Ts=%lf...\n", Ts);
   MDD_setPriority(procPrio, -2);
   for (simTime=Ts; simTime < 1.0; simTime += Ts) {
-    calculationTime = MDD_realtimeSynchronize(rtSync, simTime, &availableTime);
+    calculationTime = MDD_realtimeSynchronize(rtSync, simTime, 0, 1, &availableTime);
     printf("simTime: %lf, availableTime: %lf, calculationTime: %lf\n", simTime, availableTime, calculationTime);
     alwaysInTime = alwaysInTime && availableTime > 0;
   }
@@ -21,4 +21,3 @@ int main(void) {
 
   return !(alwaysInTime  > 0); /* Need to invert boolean value since a zero return value indicates success */
 }
-

--- a/Modelica_DeviceDrivers/Resources/test/OperatingSystem/test_MDDRealtimeSynchronize_low.c
+++ b/Modelica_DeviceDrivers/Resources/test/OperatingSystem/test_MDDRealtimeSynchronize_low.c
@@ -11,7 +11,7 @@ int main(void) {
   printf("Priority \"below normal\" with Ts=%lf...\n", Ts);
   MDD_setPriority(procPrio, -1);
   for (simTime=Ts; simTime < 1.0; simTime += Ts) {
-    calculationTime = MDD_realtimeSynchronize(rtSync, simTime, &availableTime);
+    calculationTime = MDD_realtimeSynchronize(rtSync, simTime, 0, 1, &availableTime);
     printf("simTime: %lf, availableTime: %lf, calculationTime: %lf\n", simTime, availableTime, calculationTime);
     alwaysInTime = alwaysInTime && availableTime > 0;
   }
@@ -21,4 +21,3 @@ int main(void) {
 
   return !(alwaysInTime  > 0); /* Need to invert boolean value since a zero return value indicates success */
 }
-

--- a/Modelica_DeviceDrivers/Resources/test/OperatingSystem/test_MDDRealtimeSynchronize_normal.c
+++ b/Modelica_DeviceDrivers/Resources/test/OperatingSystem/test_MDDRealtimeSynchronize_normal.c
@@ -11,7 +11,7 @@ int main(void) {
   printf("Priority \"Normal\" with Ts=%lf...\n", Ts);
   MDD_setPriority(procPrio, 0);
   for (simTime=Ts; simTime < 1.0; simTime += Ts) {
-    calculationTime = MDD_realtimeSynchronize(rtSync, simTime, &availableTime);
+    calculationTime = MDD_realtimeSynchronize(rtSync, simTime, 0, 1, &availableTime);
     printf("simTime: %lf, availableTime: %lf, calculationTime: %lf\n", simTime, availableTime, calculationTime);
     alwaysInTime = alwaysInTime && availableTime > 0;
   }
@@ -21,4 +21,3 @@ int main(void) {
 
   return !(alwaysInTime  > 0); /* Need to invert boolean value since a zero return value indicates success */
 }
-

--- a/Modelica_DeviceDrivers/Resources/test/OperatingSystem/test_MDDRealtimeSynchronize_realtime.c
+++ b/Modelica_DeviceDrivers/Resources/test/OperatingSystem/test_MDDRealtimeSynchronize_realtime.c
@@ -11,7 +11,7 @@ int main(void) {
   printf("Priority \"Realtime\" with Ts=%lf...\n", Ts);
   MDD_setPriority(procPrio, 2);
   for (simTime=Ts; simTime < 1.0; simTime += Ts) {
-    calculationTime = MDD_realtimeSynchronize(rtSync, simTime, &availableTime);
+    calculationTime = MDD_realtimeSynchronize(rtSync, simTime, 0, 1, &availableTime);
     printf("simTime: %lf, availableTime: %lf, calculationTime: %lf\n", simTime, availableTime, calculationTime);
     alwaysInTime = alwaysInTime && availableTime > 0;
   }
@@ -21,4 +21,3 @@ int main(void) {
 
   return !(alwaysInTime  > 0); /* Need to invert boolean value since a zero return value indicates success */
 }
-


### PR DESCRIPTION
Still AVR garbage has to be cleaned up.
Synchronisation time is max. 1 ms, since HAL.GetTick returns ticks in ms.
Makefile modifies generated c-file Blink_Main.c since <include stdarg> is missing. arm-non-eabi does not compile without that fix.